### PR TITLE
fix: incluir arrangement ID na URL ao editar arranjo pela lista

### DIFF
--- a/components/song/SongListEntry/index.tsx
+++ b/components/song/SongListEntry/index.tsx
@@ -244,7 +244,10 @@ export default function SongListEntry({
                 <Pencil size={14} className="mr-2" />
                 Editar dados
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={() => router.push(`/songs/${song.slug}/edit`)}>
+              <DropdownMenuItem onSelect={() => {
+                const arr = arrangements[parseInt(selectedIdx)];
+                router.push(`/songs/${song.slug}/edit?arrangement=${arr?.id}`);
+              }}>
                 <NotebookPen size={14} className="mr-2" />
                 Editar arranjo
               </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- Corrige o botão "Editar arranjo" no dropdown da lista de músicas
- Sem o `?arrangement=ID` na URL, a página de edição não sabia qual arranjo abrir e gerava erro

## Test plan
- [ ] Abrir lista de músicas
- [ ] Clicar em "..." > "Editar arranjo" numa música com arranjos
- [ ] Confirmar que abre o arranjo correto sem erro

🤖 Generated with [Claude Code](https://claude.com/claude-code)