### PR TITLE
feat: botão contextual para editar metadados da service na lista

### DIFF
--- a/app/(main)/admin/catalogo/CatalogoClient.tsx
+++ b/app/(main)/admin/catalogo/CatalogoClient.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { getLyrics } from "@/chopro/music";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { getLyrics } from "@/chopro/music";
-import { ChevronDown, ChevronRight, Trash2, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { ChevronDown, ChevronUp, Trash2, X } from "lucide-react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 type Tag = { id: number; name: string; group: { id: number; name: string; color: string } };
 type TagGroup = { id: number; name: string; color: string; tags: { id: number; name: string }[] };
@@ -16,13 +16,15 @@ type CatalogSong = {
   artist: string | null;
   lyrics: string;
   legacyId: number | null;
+  serviceCount: number;
   tags: Tag[];
 };
 type Props = { songs: CatalogSong[]; tagGroups: TagGroup[] };
+type SortKey = "title" | "artist" | "legacyId" | "serviceCount";
 
+// Colunas navegáveis pelo teclado: título + compositor + tags
 function colCount(tagGroups: TagGroup[]) {
-  // checkbox + título + compositor + tagGroups + expand
-  return 3 + tagGroups.length;
+  return 2 + tagGroups.length;
 }
 
 function focusCell(row: number, col: number) {
@@ -32,7 +34,6 @@ function focusCell(row: number, col: number) {
   input?.focus();
 }
 
-
 export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props) {
   const [songs, setSongs] = useState<CatalogSong[]>(initialSongs);
   const [search, setSearch] = useState("");
@@ -40,6 +41,8 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [bulkTagGroupId, setBulkTagGroupId] = useState<number | null>(null);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey | null>(null);
+  const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
 
   const filtered = search
     ? songs.filter(
@@ -48,6 +51,32 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
           s.artist?.toLowerCase().includes(search.toLowerCase())
       )
     : songs;
+
+  const displayed = useMemo(() => {
+    if (!sortKey) return filtered;
+    return [...filtered].sort((a, b) => {
+      let av: string | number;
+      let bv: string | number;
+      if (sortKey === "legacyId") {
+        av = a.legacyId ?? Infinity;
+        bv = b.legacyId ?? Infinity;
+      } else if (sortKey === "serviceCount") {
+        av = a.serviceCount;
+        bv = b.serviceCount;
+      } else {
+        av = (a[sortKey] ?? "").toLowerCase();
+        bv = (b[sortKey] ?? "").toLowerCase();
+      }
+      if (av < bv) return sortDir === "asc" ? -1 : 1;
+      if (av > bv) return sortDir === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [filtered, sortKey, sortDir]);
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    else { setSortKey(key); setSortDir("asc"); }
+  }
 
   const allSelected = filtered.length > 0 && filtered.every((s) => selected.has(s.slug));
   const someSelected = selected.size > 0;
@@ -174,6 +203,15 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
   }
 
   const selectedCount = [...selected].filter((s) => filtered.some((f) => f.slug === s)).length;
+  // Colunas visuais totais: checkbox + título + ID + liturgias + compositor + tags
+  const totalCols = 5 + tagGroups.length;
+
+  function SortIcon({ k }: { k: SortKey }) {
+    if (sortKey !== k) return <span className="opacity-20 ml-0.5">↕</span>;
+    return sortDir === "asc"
+      ? <ChevronUp size={10} className="inline ml-0.5" />
+      : <ChevronDown size={10} className="inline ml-0.5" />;
+  }
 
   return (
     <div className="pb-16">
@@ -281,7 +319,8 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
         <table className="w-full text-sm">
           <thead>
             <tr className="bg-muted/50 border-b border-border text-xs text-muted-foreground uppercase tracking-wide">
-              <th className="px-3 py-2.5 w-8">
+              {/* Checkbox — largura mínima */}
+              <th className="px-3 py-2.5 w-px">
                 <input
                   type="checkbox"
                   checked={allSelected}
@@ -289,30 +328,51 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                   className="rounded"
                 />
               </th>
-              <th className="px-4 py-2.5 text-left font-medium w-[25%]">Título</th>
-              <th className="px-4 py-2.5 text-left font-medium w-[18%]">Compositor</th>
+              {/* Título — auto */}
+              <th className="px-4 py-2.5 text-left font-medium">
+                <button type="button" onClick={() => handleSort("title")} className="flex items-center gap-0.5 hover:text-foreground transition-colors">
+                  Título <SortIcon k="title" />
+                </button>
+              </th>
+              {/* ID — fixo */}
+              <th className="px-3 py-2.5 text-right font-medium w-16 whitespace-nowrap">
+                <button type="button" onClick={() => handleSort("legacyId")} className="flex items-center gap-0.5 ml-auto hover:text-foreground transition-colors">
+                  ID <SortIcon k="legacyId" />
+                </button>
+              </th>
+              {/* Liturgias — fixo */}
+              <th className="px-3 py-2.5 text-right font-medium w-20 whitespace-nowrap">
+                <button type="button" onClick={() => handleSort("serviceCount")} className="flex items-center gap-0.5 ml-auto hover:text-foreground transition-colors">
+                  Liturgias <SortIcon k="serviceCount" />
+                </button>
+              </th>
+              {/* Compositor — auto */}
+              <th className="px-4 py-2.5 text-left font-medium">
+                <button type="button" onClick={() => handleSort("artist")} className="flex items-center gap-0.5 hover:text-foreground transition-colors">
+                  Compositor <SortIcon k="artist" />
+                </button>
+              </th>
               {tagGroups.map((g) => (
                 <th key={g.id} className="px-4 py-2.5 text-left font-medium whitespace-nowrap">
                   <span style={{ color: g.color }}>{g.name}</span>
                 </th>
               ))}
-              <th className="w-8" />
             </tr>
           </thead>
           <tbody
             className="divide-y divide-border"
-            onKeyDown={(e) => handleTableKeyDown(e, filtered.length)}
+            onKeyDown={(e) => handleTableKeyDown(e, displayed.length)}
           >
-            {filtered.map((song, rowIdx) => (
-              <>
+            {displayed.map((song, rowIdx) => (
+              <Fragment key={song.slug}>
                 <tr
-                  key={song.slug}
                   className={cn(
                     "hover:bg-muted/20 transition-colors",
                     selected.has(song.slug) && "bg-secondary/5"
                   )}
                 >
-                  <td className="px-3 py-1.5">
+                  {/* Checkbox */}
+                  <td className="px-3 py-1.5 w-px">
                     <input
                       type="checkbox"
                       checked={selected.has(song.slug)}
@@ -320,15 +380,42 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                       className="rounded"
                     />
                   </td>
+                  {/* Título com accordion à esquerda */}
                   <td data-row={rowIdx} data-col={0} className="px-4 py-1.5">
-                    <TextCell
-                      value={song.title}
-                      onSave={(v) => patchSong(song.slug, { title: v })}
-                    />
+                    <div className="flex items-center gap-1.5">
+                      <button
+                        type="button"
+                        tabIndex={-1}
+                        onClick={() => toggleExpand(song.slug)}
+                        className="shrink-0 text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+                        aria-label={expanded.has(song.slug) ? "Fechar letra" : "Ver letra"}
+                      >
+                        {expanded.has(song.slug)
+                          ? <ChevronUp size={13} />
+                          : <ChevronDown size={13} />
+                        }
+                      </button>
+                      <div className="flex-1 min-w-0">
+                        <TextCell
+                          value={song.title}
+                          onSave={(v) => patchSong(song.slug, { title: v })}
+                        />
+                      </div>
+                    </div>
+                  </td>
+                  {/* ID */}
+                  <td className="px-3 py-1.5 w-16 text-right">
                     {song.legacyId !== null && (
                       <span className="text-[10px] text-muted-foreground/60 font-mono">#{song.legacyId}</span>
                     )}
                   </td>
+                  {/* Liturgias */}
+                  <td className="px-3 py-1.5 w-20 text-right">
+                    {song.serviceCount > 0 && (
+                      <span className="text-xs text-muted-foreground font-mono">{song.serviceCount}</span>
+                    )}
+                  </td>
+                  {/* Compositor */}
                   <td data-row={rowIdx} data-col={1} className="px-4 py-1.5">
                     <TextCell
                       value={song.artist ?? ""}
@@ -345,36 +432,23 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                       />
                     </td>
                   ))}
-                  <td className="px-2 py-1.5">
-                    <button
-                      type="button"
-                      onClick={() => toggleExpand(song.slug)}
-                      className="text-muted-foreground/50 hover:text-muted-foreground transition-colors"
-                      aria-label={expanded.has(song.slug) ? "Fechar letra" : "Ver letra"}
-                    >
-                      {expanded.has(song.slug)
-                        ? <ChevronDown size={14} />
-                        : <ChevronRight size={14} />
-                      }
-                    </button>
-                  </td>
                 </tr>
                 {expanded.has(song.slug) && (
-                  <tr key={`${song.slug}-lyrics`} className="bg-muted/10">
+                  <tr className="bg-muted/10">
                     <td />
-                    <td colSpan={2 + tagGroups.length + 1} className="px-4 py-3">
+                    <td colSpan={totalCols - 1} className="px-4 py-3 pl-10">
                       <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-sans leading-relaxed max-h-48 overflow-y-auto">
                         {getLyrics(song.lyrics) || "Sem letra"}
                       </pre>
                     </td>
                   </tr>
                 )}
-              </>
+              </Fragment>
             ))}
-            {filtered.length === 0 && (
+            {displayed.length === 0 && (
               <tr>
                 <td
-                  colSpan={3 + tagGroups.length + 1}
+                  colSpan={totalCols}
                   className="px-4 py-8 text-center text-sm text-muted-foreground"
                 >
                   Nenhuma música encontrada.

--- a/app/(main)/admin/catalogo/CatalogoClient.tsx
+++ b/app/(main)/admin/catalogo/CatalogoClient.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { getLyrics } from "@/chopro/music";
 import { ChevronDown, ChevronRight, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -31,16 +32,6 @@ function focusCell(row: number, col: number) {
   input?.focus();
 }
 
-function stripChords(lyrics: string): string {
-  // Remove ChordPro inline chords like [Am], [G/B], [C#m7], etc.
-  return lyrics
-    .replace(/\[[^\]]*\]/g, "")
-    .replace(/\{[^}]*\}/g, "")  // remove directives like {start_of_chorus}
-    .split("\n")
-    .map((l) => l.trim())
-    .filter((l) => l.length > 0)
-    .join("\n");
-}
 
 export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props) {
   const [songs, setSongs] = useState<CatalogSong[]>(initialSongs);
@@ -125,16 +116,18 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
 
   async function bulkDelete() {
     const slugs = [...selected].filter((s) => filtered.some((f) => f.slug === s));
-    await Promise.all(
-      slugs.map((slug) =>
-        fetch(`/api/songs/${slug}`, {
+    const results = await Promise.all(
+      slugs.map(async (slug) => {
+        const res = await fetch(`/api/songs/${slug}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ isDeleted: true }),
-        })
-      )
+        });
+        return { slug, ok: res.ok };
+      })
     );
-    setSongs((prev) => prev.filter((s) => !slugs.includes(s.slug)));
+    const deleted = results.filter((r) => r.ok).map((r) => r.slug);
+    setSongs((prev) => prev.filter((s) => !deleted.includes(s.slug)));
     setSelected(new Set());
     setConfirmDelete(false);
   }
@@ -371,7 +364,7 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                     <td />
                     <td colSpan={2 + tagGroups.length + 1} className="px-4 py-3">
                       <pre className="text-xs text-muted-foreground whitespace-pre-wrap font-sans leading-relaxed max-h-48 overflow-y-auto">
-                        {stripChords(song.lyrics) || "Sem letra"}
+                        {getLyrics(song.lyrics) || "Sem letra"}
                       </pre>
                     </td>
                   </tr>

--- a/app/(main)/admin/catalogo/page.tsx
+++ b/app/(main)/admin/catalogo/page.tsx
@@ -15,6 +15,11 @@ export default async function AdminCatalogoPage() {
         artist: true,
         lyrics: true,
         legacyId: true,
+        _count: {
+          select: {
+            arrangements: { where: { isServiceArrangement: true } },
+          },
+        },
         tags: {
           select: {
             id: true,
@@ -35,13 +40,18 @@ export default async function AdminCatalogoPage() {
     }),
   ]);
 
+  const mappedSongs = songs.map((s) => ({
+    ...s,
+    serviceCount: s._count.arrangements,
+  }));
+
   return (
     <>
       <div className="px-5 sm:px-8 lg:px-14 pt-6 sm:pt-8 pb-4 sm:pb-6 lg:pb-8">
         <Heading level={1}>Catálogo</Heading>
       </div>
       <Main>
-        <CatalogoClient songs={songs} tagGroups={tagGroups} />
+        <CatalogoClient songs={mappedSongs} tagGroups={tagGroups} />
       </Main>
     </>
   );

--- a/app/api/services/[slugOrId]/route.ts
+++ b/app/api/services/[slugOrId]/route.ts
@@ -55,7 +55,7 @@ export async function PATCH(
   if ("date" in body) data.date = new Date(body.date);
 
   await import("@/prisma/client").then(({ default: prisma }) =>
-    prisma.service.update({ where: { slug: slugOrId }, data })
+    prisma.service.update({ where: { id: service.id }, data })
   );
 
   return Response.json({ success: true });

--- a/app/api/services/[slugOrId]/route.ts
+++ b/app/api/services/[slugOrId]/route.ts
@@ -39,6 +39,28 @@ export async function DELETE(
   return new Response(null, { status: 204 });
 }
 
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ slugOrId: string }> }
+) {
+  const { slugOrId } = await params;
+  const body = await request.json();
+
+  const service = await retrieveService(slugOrId);
+  if (!service) return new Response("Service not found", { status: 404 });
+
+  const data: { title?: string | null; worshipLeader?: string | null; date?: Date } = {};
+  if ("title" in body) data.title = body.title ?? null;
+  if ("worshipLeader" in body) data.worshipLeader = body.worshipLeader ?? null;
+  if ("date" in body) data.date = new Date(body.date);
+
+  await import("@/prisma/client").then(({ default: prisma }) =>
+    prisma.service.update({ where: { slug: slugOrId }, data })
+  );
+
+  return Response.json({ success: true });
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ slugOrId: string }> }

--- a/app/api/services/[slugOrId]/route.ts
+++ b/app/api/services/[slugOrId]/route.ts
@@ -51,7 +51,7 @@ export async function PATCH(
 
   const data: { title?: string | null; worshipLeader?: string | null; date?: Date } = {};
   if ("title" in body) data.title = body.title ?? null;
-  if ("worshipLeader" in body) data.worshipLeader = body.worshipLeader ?? null;
+  if ("worshipLeader" in body) data.worshipLeader = body.worshipLeader || null;
   if ("date" in body) data.date = new Date(body.date);
 
   await import("@/prisma/client").then(({ default: prisma }) =>

--- a/components/service/ServiceListEntry/index.tsx
+++ b/components/service/ServiceListEntry/index.tsx
@@ -12,7 +12,7 @@ import {
 import { ClientService } from "@/prisma/models";
 import { MoreVertical, Pencil } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
 type ServiceListEntryProps = {
@@ -26,6 +26,8 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
   const [metaOpen, setMetaOpen] = useState(false);
   const [localService, setLocalService] = useState(service);
   const { mutate } = useSWRConfig();
+
+  useEffect(() => { setLocalService(service); }, [service]);
 
   const serviceTitle = useMemo(
     () => localService.title?.trim() || t("Service.noTitle"),
@@ -43,7 +45,7 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
     [locale, localService.date]
   );
 
-  function handleMetaSave(values: ServiceMeta) {
+  function handleMetaSave(values: ServiceMeta): false {
     fetch(`/api/services/${localService.slug}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -51,8 +53,10 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
     }).then((res) => {
       if (!res.ok) return;
       setLocalService((prev) => ({ ...prev, ...values }));
+      setMetaOpen(false);
       mutate((key) => typeof key === "string" && key.startsWith("/api/services"));
-    });
+    }).catch(() => {});
+    return false;
   }
 
   const hoverClass =

--- a/components/service/ServiceListEntry/index.tsx
+++ b/components/service/ServiceListEntry/index.tsx
@@ -25,6 +25,7 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
   const locale = useLocale();
   const [metaOpen, setMetaOpen] = useState(false);
   const [localService, setLocalService] = useState(service);
+  const [saving, setSaving] = useState(false);
   const { mutate } = useSWRConfig();
 
   useEffect(() => { setLocalService(service); }, [service]);
@@ -46,6 +47,7 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
   );
 
   function handleMetaSave(values: ServiceMeta): false {
+    setSaving(true);
     fetch(`/api/services/${localService.slug}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -55,7 +57,7 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
       setLocalService((prev) => ({ ...prev, ...values }));
       setMetaOpen(false);
       mutate((key) => typeof key === "string" && key.startsWith("/api/services"));
-    }).catch(() => {});
+    }).catch(() => {}).finally(() => setSaving(false));
     return false;
   }
 
@@ -126,6 +128,7 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
           date: localService.date instanceof Date ? localService.date : new Date(String(localService.date)),
         }}
         onSave={handleMetaSave}
+        loading={saving}
       />
     </li>
   );

--- a/components/service/ServiceListEntry/index.tsx
+++ b/components/service/ServiceListEntry/index.tsx
@@ -1,7 +1,19 @@
+"use client";
+
+import ServiceMetaModal, { ServiceMeta } from "@/components/service/ServiceMetaModal";
 import Text from "@/components/common/Text";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ClientService } from "@/prisma/models";
+import { MoreVertical, Pencil } from "lucide-react";
 import { useLocale, useTranslations } from "next-intl";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
 
 type ServiceListEntryProps = {
   service: ClientService;
@@ -11,31 +23,54 @@ type ServiceListEntryProps = {
 export default function ServiceListEntry({ service, variant = "default" }: ServiceListEntryProps) {
   const t = useTranslations();
   const locale = useLocale();
+  const [metaOpen, setMetaOpen] = useState(false);
+  const [localService, setLocalService] = useState(service);
+  const { mutate } = useSWRConfig();
 
   const serviceTitle = useMemo(
-    () => service.title?.trim() || t("Service.noTitle"),
-    [service.title, t]
+    () => localService.title?.trim() || t("Service.noTitle"),
+    [localService.title, t]
   );
   const serviceDate = useMemo(
     () =>
-      new Date(String(service.date))
+      new Date(String(localService.date))
         .toLocaleDateString(locale, {
           weekday: "long",
           day: "numeric",
           month: "numeric",
         })
         .replace(/^\w/, (c) => c.toUpperCase()),
-    [locale, service.date]
+    [locale, localService.date]
   );
 
-  const linkClass =
+  function handleMetaSave(values: ServiceMeta) {
+    fetch(`/api/services/${localService.slug}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(values),
+    }).then((res) => {
+      if (!res.ok) return;
+      setLocalService((prev) => ({ ...prev, ...values }));
+      mutate((key) => typeof key === "string" && key.startsWith("/api/services"));
+    });
+  }
+
+  const hoverClass =
     variant === "card"
-      ? "flex flex-col py-2.5 px-2 -mx-2 rounded-md hover:bg-secondary/10 transition-colors"
-      : "flex flex-col py-2.5 px-2 -mx-2 rounded-md hover:bg-zinc-50 transition-colors";
+      ? "hover:bg-secondary/10"
+      : "hover:bg-zinc-50";
 
   return (
-    <li>
-      <a href={`/services/${service.slug}`} className={linkClass}>
+    <li className={`relative flex items-center gap-1 py-2.5 px-2 -mx-2 rounded-md transition-colors group ${hoverClass}`}>
+      {/* Overlay link — cobre tudo exceto o dropdown */}
+      <a
+        href={`/services/${localService.slug}`}
+        className="absolute inset-0 z-0"
+        aria-label={serviceTitle}
+      />
+
+      {/* Conteúdo — pointer-events-none para deixar o link passar */}
+      <div className="relative z-10 flex-1 min-w-0 pointer-events-none">
         <p className="font-display font-semibold text-base lg:text-lg tracking-tight leading-snug lg:leading-tight text-primary truncate">
           {serviceTitle}
         </p>
@@ -43,16 +78,51 @@ export default function ServiceListEntry({ service, variant = "default" }: Servi
           <Text variant="caption" as="span" className="text-xs md:text-sm">
             {serviceDate}
           </Text>
-          {service.worshipLeader && (
+          {localService.worshipLeader && (
             <>
               <Text variant="caption" as="span" className="text-xs md:text-sm">·</Text>
               <Text variant="caption" as="span" className="text-xs md:text-sm">
-                {service.worshipLeader}
+                {localService.worshipLeader}
               </Text>
             </>
           )}
         </div>
-      </a>
+      </div>
+
+      {/* Dropdown — z-10 para ficar acima do link overlay */}
+      <div className="relative z-10 opacity-0 group-hover:opacity-100 transition-opacity">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreVertical size={14} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={() => setMetaOpen(true)}>
+              <Pencil size={14} className="mr-2" />
+              {t("Messages.editServiceData")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      <ServiceMetaModal
+        open={metaOpen}
+        onOpenChange={setMetaOpen}
+        isNew={false}
+        defaultValues={{
+          title: localService.title ?? "",
+          worshipLeader: localService.worshipLeader ?? "",
+          date: localService.date instanceof Date ? localService.date : new Date(String(localService.date)),
+        }}
+        onSave={handleMetaSave}
+      />
     </li>
   );
 }

--- a/components/service/ServiceView/ServiceMediaButtons.tsx
+++ b/components/service/ServiceView/ServiceMediaButtons.tsx
@@ -161,10 +161,14 @@ function AudioButton({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { mutate } = useSWRConfig();
 
-  const hasAudios = audios.length > 0;
+  const hasAudios = currentAudios.length > 0;
+  const [pendingDeletes, setPendingDeletes] = useState<string[]>([]);
 
   function handleOpen(isOpen: boolean) {
-    if (isOpen) setAudios(currentAudios);
+    if (isOpen) {
+      setAudios(currentAudios);
+      setPendingDeletes([]);
+    }
     setOpen(isOpen);
   }
 
@@ -189,15 +193,9 @@ function AudioButton({
     }
   }
 
-  async function handleRemove(index: number) {
+  function handleRemove(index: number) {
     const audio = audios[index];
-    if (audio?.url) {
-      await fetch("/api/upload-audio", {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: audio.url }),
-      }).catch(() => {});
-    }
+    if (audio?.url) setPendingDeletes((prev) => [...prev, audio.url]);
     setAudios((prev) => prev.filter((_, i) => i !== index));
   }
 
@@ -205,6 +203,15 @@ function AudioButton({
     setSaving(true);
     try {
       await patchArrangementMedia(originalArrangementId, { audios });
+      await Promise.all(
+        pendingDeletes.map((url) =>
+          fetch("/api/upload-audio", {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ url }),
+          }).catch(() => {})
+        )
+      );
       mutate((key) => typeof key === "string" && key.startsWith("/api/services"));
       setOpen(false);
     } finally {
@@ -220,7 +227,7 @@ function AudioButton({
         size="icon"
         className={`h-8 w-8 md:size-9 ${hasAudios ? "border-secondary/30 text-secondary bg-secondary/10 hover:bg-secondary/20" : ""}`}
         onClick={() => setOpen(true)}
-        title={`Áudio${hasAudios ? ` (${audios.length})` : ""}`}
+        title={`Áudio${hasAudios ? ` (${currentAudios.length})` : ""}`}
       >
         <Music size={15} className={hasAudios ? "text-secondary" : "text-zinc-400"} />
       </Button>


### PR DESCRIPTION
## Summary

- Adiciona PATCH handler em `/api/services/[slugOrId]` para atualizar `title`, `worshipLeader` e `date`
- Reescreve `ServiceListEntry` como client component com dropdown contextual no hover
- Opção "Editar dados" abre o `ServiceMetaModal` pré-preenchido e salva via PATCH, atualizando o cache SWR localmente
- Melhorias no catálogo: colunas ID e Liturgias, ordenação por coluna, accordion à esquerda com chevron vertical, Tab navigation corrigida
- Correções: duplo submit no `ServiceMetaModal`, `worshipLeader` vazio salvo como `null`, blob deletion adiada para o Save

## Test plan

- [ ] Hover sobre item da lista de services — ícone ⋮ aparece
- [ ] Clicar em ⋮ → "Editar dados" abre o drawer com os dados atuais
- [ ] Salvar atualiza o item na lista sem recarregar a página
- [ ] Clicar no item (fora do botão ⋮) navega para a service normalmente
- [ ] Catálogo: colunas ID e Liturgias visíveis, clique no cabeçalho ordena
- [ ] Catálogo: Tab navega entre título, artista e colunas de tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)