### PR TITLE
feat: filtro por tags no catálogo com tri-estado incluir/excluir

### DIFF
--- a/app/(main)/admin/catalogo/CatalogoClient.tsx
+++ b/app/(main)/admin/catalogo/CatalogoClient.tsx
@@ -4,7 +4,7 @@ import { getLyrics } from "@/chopro/music";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { ChevronDown, ChevronUp, Trash2, X } from "lucide-react";
+import { ChevronDown, ChevronUp, Filter, Trash2, X } from "lucide-react";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 type Tag = { id: number; name: string; group: { id: number; name: string; color: string } };
@@ -21,8 +21,10 @@ type CatalogSong = {
 };
 type Props = { songs: CatalogSong[]; tagGroups: TagGroup[] };
 type SortKey = "title" | "artist" | "legacyId" | "serviceCount";
+type TagFilterValue = "include" | "exclude";
+type GroupFilter = { tags: Record<number, TagFilterValue>; noTag: boolean };
+type FilterState = Record<number, GroupFilter>;
 
-// Colunas navegáveis pelo teclado: título + compositor + tags
 function colCount(tagGroups: TagGroup[]) {
   return 2 + tagGroups.length;
 }
@@ -43,6 +45,24 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [sortKey, setSortKey] = useState<SortKey | null>(null);
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const [filters, setFilters] = useState<FilterState>({});
+  const [openFilterGroupId, setOpenFilterGroupId] = useState<number | null>(null);
+  const [filterPopoverPos, setFilterPopoverPos] = useState({ top: 0, left: 0 });
+  const filterPopoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (openFilterGroupId === null) return;
+    function handleOutside(e: MouseEvent) {
+      if (filterPopoverRef.current?.contains(e.target as Node)) return;
+      const triggers = document.querySelectorAll("[data-filter-trigger]");
+      for (const t of triggers) {
+        if (t.contains(e.target as Node)) return;
+      }
+      setOpenFilterGroupId(null);
+    }
+    document.addEventListener("mousedown", handleOutside);
+    return () => document.removeEventListener("mousedown", handleOutside);
+  }, [openFilterGroupId]);
 
   const filtered = search
     ? songs.filter(
@@ -73,25 +93,97 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
     });
   }, [filtered, sortKey, sortDir]);
 
+  const finalDisplay = useMemo(() => {
+    const activeGroups = Object.entries(filters).filter(
+      ([, gf]) => gf.noTag || Object.keys(gf.tags).length > 0
+    );
+    if (activeGroups.length === 0) return displayed;
+    return displayed.filter((song) => {
+      for (const [groupIdStr, gf] of activeGroups) {
+        const groupId = Number(groupIdStr);
+        const songTagsInGroup = song.tags.filter((t) => t.group.id === groupId);
+        const songTagIds = new Set(songTagsInGroup.map((t) => t.id));
+        // Excludes take priority
+        for (const [tagIdStr, mode] of Object.entries(gf.tags)) {
+          if (mode === "exclude" && songTagIds.has(Number(tagIdStr))) return false;
+        }
+        // Includes / noTag: at least one must match
+        const includeIds = Object.entries(gf.tags)
+          .filter(([, m]) => m === "include")
+          .map(([id]) => Number(id));
+        if (includeIds.length > 0 || gf.noTag) {
+          const passesNoTag = gf.noTag && songTagsInGroup.length === 0;
+          const passesInclude = includeIds.some((id) => songTagIds.has(id));
+          if (!passesNoTag && !passesInclude) return false;
+        }
+      }
+      return true;
+    });
+  }, [displayed, filters]);
+
   function handleSort(key: SortKey) {
     if (sortKey === key) setSortDir((d) => (d === "asc" ? "desc" : "asc"));
     else { setSortKey(key); setSortDir("asc"); }
   }
 
-  const allSelected = filtered.length > 0 && filtered.every((s) => selected.has(s.slug));
+  function getGroupFilter(groupId: number): GroupFilter {
+    return filters[groupId] ?? { tags: {}, noTag: false };
+  }
+
+  function hasActiveFilter(groupId: number) {
+    const gf = filters[groupId];
+    return !!gf && (gf.noTag || Object.keys(gf.tags).length > 0);
+  }
+
+  function cycleTagFilter(groupId: number, tagId: number) {
+    setFilters((prev) => {
+      const gf = prev[groupId] ?? { tags: {}, noTag: false };
+      const cur = gf.tags[tagId];
+      const next: TagFilterValue | undefined =
+        cur === undefined ? "include" : cur === "include" ? "exclude" : undefined;
+      const nextTags = { ...gf.tags };
+      if (next === undefined) delete nextTags[tagId];
+      else nextTags[tagId] = next;
+      return { ...prev, [groupId]: { ...gf, tags: nextTags } };
+    });
+  }
+
+  function toggleNoTag(groupId: number) {
+    setFilters((prev) => {
+      const gf = prev[groupId] ?? { tags: {}, noTag: false };
+      return { ...prev, [groupId]: { ...gf, noTag: !gf.noTag } };
+    });
+  }
+
+  function clearGroupFilter(groupId: number) {
+    setFilters((prev) => {
+      const next = { ...prev };
+      delete next[groupId];
+      return next;
+    });
+  }
+
+  function openFilter(e: React.MouseEvent<HTMLButtonElement>, groupId: number) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    setFilterPopoverPos({ top: rect.bottom + 4, left: rect.left });
+    setOpenFilterGroupId((prev) => (prev === groupId ? null : groupId));
+  }
+
+  const allSelected =
+    finalDisplay.length > 0 && finalDisplay.every((s) => selected.has(s.slug));
   const someSelected = selected.size > 0;
 
   function toggleAll() {
     if (allSelected) {
       setSelected((prev) => {
         const next = new Set(prev);
-        filtered.forEach((s) => next.delete(s.slug));
+        finalDisplay.forEach((s) => next.delete(s.slug));
         return next;
       });
     } else {
       setSelected((prev) => {
         const next = new Set(prev);
-        filtered.forEach((s) => next.add(s.slug));
+        finalDisplay.forEach((s) => next.add(s.slug));
         return next;
       });
     }
@@ -113,7 +205,10 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
     });
   }
 
-  async function patchSong(slug: string, data: { title?: string; artist?: string | null; tagIds?: number[] }) {
+  async function patchSong(
+    slug: string,
+    data: { title?: string; artist?: string | null; tagIds?: number[] }
+  ) {
     const res = await fetch(`/api/songs/${slug}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
@@ -144,7 +239,7 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
   }
 
   async function bulkDelete() {
-    const slugs = [...selected].filter((s) => filtered.some((f) => f.slug === s));
+    const slugs = [...selected].filter((s) => finalDisplay.some((f) => f.slug === s));
     const results = await Promise.all(
       slugs.map(async (slug) => {
         const res = await fetch(`/api/songs/${slug}`, {
@@ -162,10 +257,9 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
   }
 
   async function bulkSetTag(groupId: number, tagId: number | null) {
-    const slugs = [...selected].filter((s) => filtered.some((f) => f.slug === s));
+    const slugs = [...selected].filter((s) => finalDisplay.some((f) => f.slug === s));
     const group = tagGroups.find((g) => g.id === groupId);
     if (!group) return;
-
     await Promise.all(
       slugs.map((slug) => {
         const song = songs.find((s) => s.slug === slug);
@@ -185,7 +279,6 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
     const col = parseInt(td.dataset.col ?? "-1");
     if (row === -1 || col === -1) return;
     const cols = colCount(tagGroups);
-
     if (e.key === "Tab" && !e.shiftKey) {
       e.preventDefault();
       const nextCol = col + 1 < cols ? col + 1 : 0;
@@ -202,9 +295,11 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
     }
   }
 
-  const selectedCount = [...selected].filter((s) => filtered.some((f) => f.slug === s)).length;
-  // Colunas visuais totais: checkbox + título + ID + liturgias + compositor + tags
+  const selectedCount = [...selected].filter((s) => finalDisplay.some((f) => f.slug === s)).length;
   const totalCols = 5 + tagGroups.length;
+  const hasActiveFilters = Object.values(filters).some(
+    (gf) => gf.noTag || Object.keys(gf.tags).length > 0
+  );
 
   function SortIcon({ k }: { k: SortKey }) {
     if (sortKey !== k) return <span className="opacity-20 ml-0.5">↕</span>;
@@ -226,9 +321,10 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
 
         {someSelected && (
           <div className="flex items-center gap-2 ml-auto">
-            <span className="text-xs text-muted-foreground">{selectedCount} selecionada{selectedCount !== 1 ? "s" : ""}</span>
+            <span className="text-xs text-muted-foreground">
+              {selectedCount} selecionada{selectedCount !== 1 ? "s" : ""}
+            </span>
 
-            {/* Bulk tag */}
             <div className="relative">
               <Button
                 type="button"
@@ -253,7 +349,11 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                             ? "text-white"
                             : "text-muted-foreground border-transparent"
                         )}
-                        style={bulkTagGroupId === g.id ? { backgroundColor: g.color, borderColor: g.color } : {}}
+                        style={
+                          bulkTagGroupId === g.id
+                            ? { backgroundColor: g.color, borderColor: g.color }
+                            : {}
+                        }
                       >
                         {g.name}
                       </button>
@@ -288,14 +388,25 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
               )}
             </div>
 
-            {/* Bulk delete */}
             {confirmDelete ? (
               <div className="flex items-center gap-1.5">
                 <span className="text-xs text-destructive">Confirmar exclusão?</span>
-                <Button type="button" variant="destructive" size="sm" className="h-7 text-xs" onClick={bulkDelete}>
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={bulkDelete}
+                >
                   Excluir
                 </Button>
-                <Button type="button" variant="ghost" size="sm" className="h-7 text-xs" onClick={() => setConfirmDelete(false)}>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 text-xs"
+                  onClick={() => setConfirmDelete(false)}
+                >
                   Cancelar
                 </Button>
               </div>
@@ -315,11 +426,60 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
         )}
       </div>
 
+      {/* Active filter chips */}
+      {hasActiveFilters && (
+        <div className="mb-3 flex items-center gap-1.5 flex-wrap">
+          <span className="text-xs text-muted-foreground">Filtros:</span>
+          {tagGroups.map((g) => {
+            if (!hasActiveFilter(g.id)) return null;
+            const gf = getGroupFilter(g.id);
+            const includeIds = Object.entries(gf.tags)
+              .filter(([, m]) => m === "include")
+              .map(([id]) => Number(id));
+            const excludeIds = Object.entries(gf.tags)
+              .filter(([, m]) => m === "exclude")
+              .map(([id]) => Number(id));
+            return (
+              <div
+                key={g.id}
+                className="inline-flex items-center gap-1 text-xs border rounded-full px-2 py-0.5"
+                style={{ borderColor: `${g.color}66`, backgroundColor: `${g.color}12` }}
+              >
+                <span className="font-medium" style={{ color: g.color }}>
+                  {g.name}:
+                </span>
+                {gf.noTag && (
+                  <span className="text-muted-foreground">sem tag</span>
+                )}
+                {includeIds.map((id) => {
+                  const tag = g.tags.find((t) => t.id === id);
+                  return tag ? (
+                    <span key={id} className="text-emerald-600">✓{tag.name}</span>
+                  ) : null;
+                })}
+                {excludeIds.map((id) => {
+                  const tag = g.tags.find((t) => t.id === id);
+                  return tag ? (
+                    <span key={id} className="text-red-500">✗{tag.name}</span>
+                  ) : null;
+                })}
+                <button
+                  type="button"
+                  onClick={() => clearGroupFilter(g.id)}
+                  className="ml-0.5 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <X size={10} />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
       <div className="rounded-lg border border-border overflow-x-auto">
         <table className="w-full text-sm">
           <thead>
             <tr className="bg-muted/50 border-b border-border text-xs text-muted-foreground uppercase tracking-wide">
-              {/* Checkbox — largura mínima */}
               <th className="px-3 py-2.5 w-px">
                 <input
                   type="checkbox"
@@ -328,42 +488,70 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                   className="rounded"
                 />
               </th>
-              {/* Título — auto */}
               <th className="px-4 py-2.5 text-left font-medium">
-                <button type="button" onClick={() => handleSort("title")} className="flex items-center gap-0.5 hover:text-foreground transition-colors">
+                <button
+                  type="button"
+                  onClick={() => handleSort("title")}
+                  className="flex items-center gap-0.5 hover:text-foreground transition-colors"
+                >
                   Título <SortIcon k="title" />
                 </button>
               </th>
-              {/* ID — fixo */}
               <th className="px-3 py-2.5 text-right font-medium w-16 whitespace-nowrap">
-                <button type="button" onClick={() => handleSort("legacyId")} className="flex items-center gap-0.5 ml-auto hover:text-foreground transition-colors">
+                <button
+                  type="button"
+                  onClick={() => handleSort("legacyId")}
+                  className="flex items-center gap-0.5 ml-auto hover:text-foreground transition-colors"
+                >
                   ID <SortIcon k="legacyId" />
                 </button>
               </th>
-              {/* Liturgias — fixo */}
               <th className="px-3 py-2.5 text-right font-medium w-20 whitespace-nowrap">
-                <button type="button" onClick={() => handleSort("serviceCount")} className="flex items-center gap-0.5 ml-auto hover:text-foreground transition-colors">
+                <button
+                  type="button"
+                  onClick={() => handleSort("serviceCount")}
+                  className="flex items-center gap-0.5 ml-auto hover:text-foreground transition-colors"
+                >
                   Liturgias <SortIcon k="serviceCount" />
                 </button>
               </th>
-              {/* Compositor — auto */}
               <th className="px-4 py-2.5 text-left font-medium">
-                <button type="button" onClick={() => handleSort("artist")} className="flex items-center gap-0.5 hover:text-foreground transition-colors">
+                <button
+                  type="button"
+                  onClick={() => handleSort("artist")}
+                  className="flex items-center gap-0.5 hover:text-foreground transition-colors"
+                >
                   Compositor <SortIcon k="artist" />
                 </button>
               </th>
               {tagGroups.map((g) => (
                 <th key={g.id} className="px-4 py-2.5 text-left font-medium whitespace-nowrap">
-                  <span style={{ color: g.color }}>{g.name}</span>
+                  <div className="flex items-center gap-1">
+                    <span style={{ color: g.color }}>{g.name}</span>
+                    <button
+                      type="button"
+                      data-filter-trigger
+                      onClick={(e) => openFilter(e, g.id)}
+                      className={cn(
+                        "p-0.5 rounded transition-colors",
+                        hasActiveFilter(g.id)
+                          ? "text-primary"
+                          : "text-muted-foreground/30 hover:text-muted-foreground"
+                      )}
+                      title={`Filtrar por ${g.name}`}
+                    >
+                      <Filter size={10} />
+                    </button>
+                  </div>
                 </th>
               ))}
             </tr>
           </thead>
           <tbody
             className="divide-y divide-border"
-            onKeyDown={(e) => handleTableKeyDown(e, displayed.length)}
+            onKeyDown={(e) => handleTableKeyDown(e, finalDisplay.length)}
           >
-            {displayed.map((song, rowIdx) => (
+            {finalDisplay.map((song, rowIdx) => (
               <Fragment key={song.slug}>
                 <tr
                   className={cn(
@@ -371,7 +559,6 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                     selected.has(song.slug) && "bg-secondary/5"
                   )}
                 >
-                  {/* Checkbox */}
                   <td className="px-3 py-1.5 w-px">
                     <input
                       type="checkbox"
@@ -380,7 +567,6 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                       className="rounded"
                     />
                   </td>
-                  {/* Título com accordion à esquerda */}
                   <td data-row={rowIdx} data-col={0} className="px-4 py-1.5">
                     <div className="flex items-center gap-1.5">
                       <button
@@ -392,8 +578,7 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                       >
                         {expanded.has(song.slug)
                           ? <ChevronUp size={13} />
-                          : <ChevronDown size={13} />
-                        }
+                          : <ChevronDown size={13} />}
                       </button>
                       <div className="flex-1 min-w-0">
                         <TextCell
@@ -403,19 +588,20 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                       </div>
                     </div>
                   </td>
-                  {/* ID */}
                   <td className="px-3 py-1.5 w-16 text-right">
                     {song.legacyId !== null && (
-                      <span className="text-[10px] text-muted-foreground/60 font-mono">#{song.legacyId}</span>
+                      <span className="text-[10px] text-muted-foreground/60 font-mono">
+                        #{song.legacyId}
+                      </span>
                     )}
                   </td>
-                  {/* Liturgias */}
                   <td className="px-3 py-1.5 w-20 text-right">
                     {song.serviceCount > 0 && (
-                      <span className="text-xs text-muted-foreground font-mono">{song.serviceCount}</span>
+                      <span className="text-xs text-muted-foreground font-mono">
+                        {song.serviceCount}
+                      </span>
                     )}
                   </td>
-                  {/* Compositor */}
                   <td data-row={rowIdx} data-col={1} className="px-4 py-1.5">
                     <TextCell
                       value={song.artist ?? ""}
@@ -445,7 +631,7 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
                 )}
               </Fragment>
             ))}
-            {displayed.length === 0 && (
+            {finalDisplay.length === 0 && (
               <tr>
                 <td
                   colSpan={totalCols}
@@ -458,8 +644,103 @@ export default function CatalogoClient({ songs: initialSongs, tagGroups }: Props
           </tbody>
         </table>
       </div>
+
+      {/* Filter popover — fixed-positioned to escape overflow:hidden */}
+      {openFilterGroupId !== null && (() => {
+        const group = tagGroups.find((g) => g.id === openFilterGroupId);
+        if (!group) return null;
+        const gf = getGroupFilter(group.id);
+        return (
+          <div
+            ref={filterPopoverRef}
+            style={{ position: "fixed", top: filterPopoverPos.top, left: filterPopoverPos.left }}
+            className="z-[9999] bg-background border border-border rounded-md shadow-lg py-1.5 min-w-[180px]"
+          >
+            <button
+              type="button"
+              onClick={() => toggleNoTag(group.id)}
+              className={cn(
+                "w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 transition-colors",
+                gf.noTag ? "text-primary" : "text-muted-foreground hover:bg-muted"
+              )}
+            >
+              <FilterDot active={gf.noTag} mode={null} />
+              Sem {group.name}
+            </button>
+            {group.tags.length > 0 && <div className="border-t border-border my-1" />}
+            {group.tags.map((tag) => {
+              const mode = gf.tags[tag.id];
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => cycleTagFilter(group.id, tag.id)}
+                  className="w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 hover:bg-muted transition-colors"
+                >
+                  <FilterDot active={mode !== undefined} mode={mode ?? null} />
+                  <span
+                    className={cn(
+                      mode === "include"
+                        ? "text-emerald-700"
+                        : mode === "exclude"
+                        ? "text-red-600"
+                        : ""
+                    )}
+                  >
+                    {tag.name}
+                  </span>
+                </button>
+              );
+            })}
+            {hasActiveFilter(group.id) && (
+              <>
+                <div className="border-t border-border my-1" />
+                <button
+                  type="button"
+                  onClick={() => clearGroupFilter(group.id)}
+                  className="w-full text-center px-3 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                >
+                  Limpar
+                </button>
+              </>
+            )}
+          </div>
+        );
+      })()}
     </div>
   );
+}
+
+// ─── FilterDot ────────────────────────────────────────────────────────────────
+
+function FilterDot({
+  active,
+  mode,
+}: {
+  active: boolean;
+  mode: "include" | "exclude" | null;
+}) {
+  if (!active) {
+    return (
+      <span className="w-3.5 h-3.5 rounded-full border border-muted-foreground/30 shrink-0" />
+    );
+  }
+  if (mode === "include") {
+    return (
+      <span className="w-3.5 h-3.5 rounded-full bg-emerald-500 shrink-0 flex items-center justify-center text-white font-bold leading-none">
+        <span style={{ fontSize: 8 }}>✓</span>
+      </span>
+    );
+  }
+  if (mode === "exclude") {
+    return (
+      <span className="w-3.5 h-3.5 rounded-full bg-red-500 shrink-0 flex items-center justify-center text-white font-bold leading-none">
+        <span style={{ fontSize: 8 }}>✕</span>
+      </span>
+    );
+  }
+  // noTag active
+  return <span className="w-3.5 h-3.5 rounded-full bg-primary shrink-0" />;
 }
 
 // ─── TextCell ────────────────────────────────────────────────────────────────
@@ -516,7 +797,9 @@ function TagGroupCell({
 
   const selectedIds = new Set(selectedTags.map((t) => t.id));
   const suggestions = group.tags.filter(
-    (t) => !selectedIds.has(t.id) && (!query || t.name.toLowerCase().includes(query.toLowerCase()))
+    (t) =>
+      !selectedIds.has(t.id) &&
+      (!query || t.name.toLowerCase().includes(query.toLowerCase()))
   );
 
   useEffect(() => setHighlighted(0), [suggestions.length, query]);


### PR DESCRIPTION
## Summary

- Ícone de funil (⛉) no cabeçalho de cada coluna de tag — discreto no hover, colorido quando filtro ativo
- Popover ao clicar: opção **Sem [grupo]** + cada tag com tri-estado (clique cicla: neutro → ✓ incluir → ✗ excluir)
- Chips de filtro ativo acima da tabela com botão × para limpar por grupo
- Lógica de filtro: excludes têm prioridade; includes e "sem tag" funcionam em OR dentro do grupo; múltiplos grupos filtram em AND

## Test plan

- [ ] Clicar no funil de uma coluna de tag — popover abre com as opções do grupo
- [ ] Clicar em uma tag → ✓ (incluir): apenas músicas com essa tag aparecem
- [ ] Clicar novamente → ✗ (excluir): músicas com essa tag são removidas da lista
- [ ] Clicar novamente → neutro: filtro removido
- [ ] "Sem [grupo]": mostra apenas músicas sem nenhuma tag naquele grupo
- [ ] Combinar "Sem [grupo]" + incluir outra tag: mostra músicas sem tag OU com a tag incluída
- [ ] Chip de filtro ativo aparece acima da tabela; × limpa o filtro do grupo
- [ ] Dois grupos com filtros ativos combinam em AND

🤖 Generated with [Claude Code](https://claude.com/claude-code)