### PR TITLE
fix: notação de sétima maior de M7 para 7M

### DIFF
--- a/chopro/chord-grid.ts
+++ b/chopro/chord-grid.ts
@@ -13,10 +13,10 @@ export type ChordRow = {
 
 // Reference grid in C major — all other keys computed via transposeChord
 const C_GRID: ChordRow[] = [
-  { triad: "C",    seventh: "CM7",   slash: null,  variante: "C7", varType: "aem",    romanLabel: "I" },
+  { triad: "C",    seventh: "C7M",   slash: null,  variante: "C7", varType: "aem",    romanLabel: "I" },
   { triad: "Dm",   seventh: "Dm7",   slash: null,  variante: "A7", varType: "secdom", romanLabel: "IIm" },
   { triad: "Em",   seventh: "Em7",   slash: "C/E", variante: "B7", varType: "secdom", romanLabel: "IIIm" },
-  { triad: "F",    seventh: "FM7",   slash: null,  variante: "Fm", varType: "aem",    romanLabel: "IV" },
+  { triad: "F",    seventh: "F7M",   slash: null,  variante: "Fm", varType: "aem",    romanLabel: "IV" },
   { triad: "G",    seventh: "G7",    slash: null,  variante: null, varType: null,     romanLabel: "V" },
   { triad: "Am",   seventh: "Am7",   slash: null,  variante: "E7", varType: "secdom", romanLabel: "VIm" },
   { triad: "Bdim", seventh: "Bm7b5", slash: "G/B", variante: null, varType: null,     romanLabel: "VIIdim" },


### PR DESCRIPTION
## Summary

- Substitui a notação `CM7`/`FM7` por `C7M`/`F7M` no dicionário de acordes (`chopro/chord-grid.ts`)
- A transposição para outras tonalidades preserva o sufixo automaticamente, sem nenhuma alteração adicional necessária

🤖 Generated with [Claude Code](https://claude.com/claude-code)