### PR TITLE
feat: integração com Holyrics

### DIFF
--- a/app/(main)/admin/holyrics/HolyricsAdminClient.tsx
+++ b/app/(main)/admin/holyrics/HolyricsAdminClient.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  holyricsPopupCreateSong,
+  holyricsSearchSong,
+} from "@/lib/holyrics";
+import { ClientArrangement } from "@/prisma/models";
+import { CheckCircle2, Circle, Loader2, RefreshCw, Settings, Unlink, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+
+type ArrangementOption = {
+  id: number;
+  key: string;
+  name: string | null;
+  isDefault: boolean;
+  units: { content: string; type: string; order: number }[];
+};
+
+type SongRow = {
+  slug: string;
+  title: string;
+  artist: string | null;
+  holyricsId: string | null;
+  arrangements: ArrangementOption[];
+  usedInServices: boolean;
+};
+
+function arrangementLabel(a: ArrangementOption) {
+  return a.name ? `${a.name} (${a.key})` : a.key;
+}
+
+// searching    → buscando no Holyrics
+// not_found    → não existe no Holyrics, precisa criar
+// popup_open   → popup aberto no Holyrics, aguardando o usuário salvar
+// linking      → buscando ID após o usuário salvar no Holyrics
+// linked       → vinculado com sucesso
+// error        → algo deu errado
+type SongStatus = "idle" | "searching" | "not_found" | "popup_open" | "linking" | "linked" | "error";
+
+type Props = {
+  songs: SongRow[];
+  initialToken: string;
+  initialHost: string;
+};
+
+export default function HolyricsAdminClient({ songs: initialSongs, initialToken, initialHost }: Props) {
+  const [songs, setSongs] = useState(initialSongs);
+  const [token, setToken] = useState(initialToken);
+  const [host, setHost] = useState(initialHost);
+  const [showSettings, setShowSettings] = useState(false);
+  const [savingConfig, setSavingConfig] = useState(false);
+  const [statuses, setStatuses] = useState<Record<string, SongStatus>>({});
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [manualIds, setManualIds] = useState<Record<string, string>>({});
+  const [selectedArrangementIds, setSelectedArrangementIds] = useState<Record<string, number>>({});
+
+  const [onlyInServices, setOnlyInServices] = useState(false);
+  const [wizardActive, setWizardActive] = useState(false);
+  const [wizardIndex, setWizardIndex] = useState(0);
+  // Fila estável: calculada uma vez ao iniciar o wizard.
+  // Não pode derivar de `songs` dinamicamente — quando uma música é vinculada
+  // durante o wizard, ela sai de visibleSongs e o índice aponta para a errada.
+  const [wizardQueue, setWizardQueue] = useState<SongRow[]>([]);
+
+  const visibleSongs = onlyInServices ? songs.filter((s) => s.usedInServices) : songs;
+  const pendingSongs = visibleSongs.filter((s) => !s.holyricsId);
+  const currentWizardSong = wizardQueue[wizardIndex];
+
+  // Ao avançar o wizard, busca automaticamente no Holyrics
+  useEffect(() => {
+    if (!wizardActive || !currentWizardSong) return;
+    const slug = currentWizardSong.slug;
+    const st = statuses[slug];
+    if (st && st !== "idle" && st !== "error") return; // já processando
+    searchAndMaybeLink(currentWizardSong);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [wizardActive, wizardIndex, wizardQueue]);
+
+  function setStatus(slug: string, status: SongStatus) {
+    setStatuses((prev) => ({ ...prev, [slug]: status }));
+  }
+
+  function setError(slug: string, msg: string) {
+    setErrors((prev) => ({ ...prev, [slug]: msg }));
+  }
+
+  async function handleSaveConfig() {
+    setSavingConfig(true);
+    await fetch("/api/holyrics-config", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token, host }),
+    });
+    setSavingConfig(false);
+    setShowSettings(false);
+  }
+
+  async function persistHolyricsId(slug: string, holyricsId: string) {
+    await fetch(`/api/songs/${slug}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ holyricsId }),
+    });
+    setSongs((prev) => prev.map((s) => (s.slug === slug ? { ...s, holyricsId } : s)));
+  }
+
+  async function unlinkSong(slug: string) {
+    await fetch(`/api/songs/${slug}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ holyricsId: null }),
+    });
+    setSongs((prev) => prev.map((s) => (s.slug === slug ? { ...s, holyricsId: null } : s)));
+    setStatus(slug, "idle");
+  }
+
+  // Busca no Holyrics primeiro. Se encontrar, vincula direto.
+  // Se não encontrar, muda para not_found (mostra botão de criar).
+  async function searchAndMaybeLink(song: SongRow): Promise<boolean> {
+    setStatus(song.slug, "searching");
+    setError(song.slug, "");
+    try {
+      const id = await holyricsSearchSong(token, host, song.title);
+      if (id) {
+        await persistHolyricsId(song.slug, id);
+        setStatus(song.slug, "linked");
+        return true;
+      }
+      setStatus(song.slug, "not_found");
+      return false;
+    } catch (e) {
+      setError(song.slug, (e as Error).message);
+      setStatus(song.slug, "error");
+      return false;
+    }
+  }
+
+  function getSelectedArrangement(song: SongRow): ArrangementOption | undefined {
+    const selectedId = selectedArrangementIds[song.slug];
+    if (selectedId != null) {
+      const found = song.arrangements.find((a) => a.id === selectedId);
+      if (found) return found;
+    }
+    return song.arrangements.find((a) => a.isDefault) ?? song.arrangements[0];
+  }
+
+  // Abre o popup de criação no Holyrics, usando o arranjo selecionado para a letra
+  async function openPopup(song: SongRow) {
+    setStatus(song.slug, "popup_open");
+    setError(song.slug, "");
+    try {
+      const units = getSelectedArrangement(song)?.units ?? [];
+      const arrangement = { units } as unknown as ClientArrangement;
+      await holyricsPopupCreateSong(song.title, song.artist, arrangement, host);
+    } catch {
+      setError(song.slug, "Não foi possível conectar ao Holyrics. Verifique se o programa está aberto e o API Server ativado.");
+      setStatus(song.slug, "error");
+    }
+  }
+
+  // Após o usuário salvar no Holyrics, busca o ID gerado e vincula
+  async function linkAfterSave(song: SongRow) {
+    setStatus(song.slug, "linking");
+    setError(song.slug, "");
+    try {
+      const id = await holyricsSearchSong(token, host, song.title);
+      if (!id) throw new Error(`"${song.title}" não foi encontrada pelo título. Se o título no Holyrics é diferente, cole o ID da música abaixo.`);
+      await persistHolyricsId(song.slug, id);
+      setStatus(song.slug, "linked");
+    } catch (e) {
+      setError(song.slug, (e as Error).message);
+      setStatus(song.slug, "error");
+    }
+  }
+
+  async function linkManually(song: SongRow) {
+    const id = manualIds[song.slug]?.trim();
+    if (!id) return;
+    setStatus(song.slug, "linking");
+    setError(song.slug, "");
+    try {
+      await persistHolyricsId(song.slug, id);
+      setStatus(song.slug, "linked");
+      setManualIds((prev) => ({ ...prev, [song.slug]: "" }));
+    } catch (e) {
+      setError(song.slug, (e as Error).message);
+      setStatus(song.slug, "error");
+    }
+  }
+
+  // Wizard: vincula (ou cria) e avança
+  async function wizardLinkAfterSave() {
+    if (!currentWizardSong) return;
+    await linkAfterSave(currentWizardSong);
+    advanceWizard();
+  }
+
+  function advanceWizard() {
+    if (wizardIndex < wizardQueue.length - 1) {
+      setWizardIndex((i) => i + 1);
+    } else {
+      setWizardActive(false);
+    }
+  }
+
+  // Wizard: para músicas auto-vinculadas, avança sem interação do usuário
+  useEffect(() => {
+    if (!wizardActive || !currentWizardSong) return;
+    if (statuses[currentWizardSong.slug] === "linked") {
+      const t = setTimeout(advanceWizard, 600);
+      return () => clearTimeout(t);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statuses, wizardActive, wizardIndex]);
+
+  const linked = visibleSongs.filter((s) => s.holyricsId).length;
+
+  return (
+    <div className="space-y-6">
+      {/* Token e Host */}
+      <div className="border rounded-lg p-4 bg-zinc-50">
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="font-medium text-sm">Configuração Holyrics</span>
+            <div className="ml-3 text-sm text-muted-foreground font-mono space-y-0.5">
+              <div>Host: {host || "não configurado"}</div>
+              <div>Token: {token ? `${token.slice(0, 6)}…` : "não configurado"}</div>
+            </div>
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={() => setShowSettings((v) => !v)}>
+            <Settings size={16} className="mr-1" /> Configurar
+          </Button>
+        </div>
+
+        {showSettings && (
+          <div className="mt-4 space-y-3">
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">
+                Host do Holyrics (ex: localhost:8091 ou 192.168.1.100:8091)
+              </label>
+              <input
+                className="border rounded px-2 py-1 text-sm w-full font-mono"
+                value={host}
+                onChange={(e) => setHost(e.target.value)}
+                placeholder="localhost:8091"
+              />
+            </div>
+            <div>
+              <label className="text-xs text-muted-foreground block mb-1">
+                Token (Holyrics → API Server → Gerenciar permissões)
+              </label>
+              <input
+                className="border rounded px-2 py-1 text-sm w-full font-mono"
+                value={token}
+                onChange={(e) => setToken(e.target.value)}
+                placeholder="abcdef"
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button type="button" size="sm" onClick={handleSaveConfig} disabled={savingConfig}>
+                {savingConfig && <Loader2 size={14} className="mr-1 animate-spin" />}
+                Salvar
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Filtro + Progresso */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{linked}</span> de {visibleSongs.length} vinculadas
+          </div>
+          <label className="flex items-center gap-1.5 text-sm text-muted-foreground cursor-pointer select-none">
+            <input
+              type="checkbox"
+              className="accent-emerald-600"
+              checked={onlyInServices}
+              onChange={(e) => { setOnlyInServices(e.target.checked); setWizardActive(false); }}
+            />
+            Apenas músicas em cultos
+          </label>
+        </div>
+        {pendingSongs.length > 0 && (
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => { setWizardQueue(pendingSongs); setWizardIndex(0); setWizardActive(true); }}
+            disabled={wizardActive}
+          >
+            Vincular pendentes ({pendingSongs.length})
+          </Button>
+        )}
+      </div>
+
+      {/* Wizard */}
+      {wizardActive && currentWizardSong && (
+        <WizardCard
+          song={currentWizardSong}
+          status={statuses[currentWizardSong.slug] ?? "searching"}
+          error={errors[currentWizardSong.slug] ?? ""}
+          index={wizardIndex}
+          total={wizardQueue.length}
+          manualId={manualIds[currentWizardSong.slug] ?? ""}
+          selectedArrangementId={getSelectedArrangement(currentWizardSong)?.id}
+          onOpenPopup={() => openPopup(currentWizardSong)}
+          onLinkAfterSave={wizardLinkAfterSave}
+          onRetry={() => searchAndMaybeLink(currentWizardSong)}
+          onPause={() => setWizardActive(false)}
+          onManualIdChange={(v) => setManualIds((prev) => ({ ...prev, [currentWizardSong.slug]: v }))}
+          onLinkManually={() => { linkManually(currentWizardSong).then(advanceWizard); }}
+          onArrangementChange={(id) => setSelectedArrangementIds((prev) => ({ ...prev, [currentWizardSong.slug]: id }))}
+        />
+      )}
+      {wizardActive && !currentWizardSong && (
+        <div className="border-2 border-emerald-500 rounded-lg p-5 bg-emerald-50 text-center">
+          <CheckCircle2 size={24} className="text-emerald-500 mx-auto mb-2" />
+          <p className="font-medium text-emerald-800">Todas as músicas vinculadas!</p>
+        </div>
+      )}
+
+      {/* Lista */}
+      <div className="border rounded-lg divide-y">
+        {visibleSongs.map((song) => {
+          const status = statuses[song.slug] ?? (song.holyricsId ? "linked" : "idle");
+          const isLinked = !!song.holyricsId;
+          const isCurrentWizardSong = wizardActive && currentWizardSong?.slug === song.slug;
+          const needsGuidance =
+            !wizardActive &&
+            (status === "not_found" || status === "popup_open" || (status === "error" && !isLinked));
+          return (
+            <div
+              key={song.slug}
+              className={`px-4 py-3 ${isCurrentWizardSong ? "bg-emerald-50" : ""}`}
+            >
+              <div className="flex items-center gap-3">
+                <StatusIcon status={isLinked ? "linked" : status} />
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm font-medium truncate">{song.title}</div>
+                  {song.artist && (
+                    <div className="text-xs text-muted-foreground truncate">{song.artist}</div>
+                  )}
+                  {isLinked && (
+                    <div className="text-xs text-emerald-600">Vinculada ao Holyrics</div>
+                  )}
+                  {errors[song.slug] && !wizardActive && (
+                    <div className="text-xs text-red-600 mt-0.5">{errors[song.slug]}</div>
+                  )}
+                </div>
+                {/* Durante o wizard, ação só no card acima — sem botões na lista */}
+                {!wizardActive && (
+                  <div className="flex gap-2 shrink-0">
+                    {!isLinked && status === "idle" && (
+                      <Button type="button" size="sm" variant="outline" onClick={() => searchAndMaybeLink(song)}>
+                        Vincular
+                      </Button>
+                    )}
+                    {!isLinked && (status === "searching" || status === "linking") && (
+                      <Loader2 size={16} className="animate-spin text-muted-foreground" />
+                    )}
+                    {!isLinked && status === "not_found" && (
+                      <Button type="button" size="sm" onClick={() => openPopup(song)}>
+                        Criar no Holyrics
+                      </Button>
+                    )}
+                    {!isLinked && status === "popup_open" && (
+                      <Button type="button" size="sm" variant="outline" onClick={() => linkAfterSave(song)}>
+                        Já salvei →
+                      </Button>
+                    )}
+                    {!isLinked && status === "error" && (
+                      <Button type="button" size="sm" variant="outline" onClick={() => searchAndMaybeLink(song)}>
+                        Tentar novamente
+                      </Button>
+                    )}
+                    {isLinked && status === "linked" && (
+                      <>
+                        <Button type="button" size="sm" variant="ghost" onClick={() => openPopup(song)}>
+                          <RefreshCw size={14} className="mr-1" /> Ressincronizar
+                        </Button>
+                        <Button type="button" size="sm" variant="ghost" onClick={() => unlinkSong(song.slug)}>
+                          <Unlink size={14} />
+                        </Button>
+                      </>
+                    )}
+                    {isLinked && status === "popup_open" && (
+                      <Button type="button" size="sm" variant="outline" onClick={() => setStatus(song.slug, "linked")}>
+                        Concluído
+                      </Button>
+                    )}
+                    {isLinked && status === "error" && (
+                      <Button type="button" size="sm" variant="ghost" onClick={() => setStatus(song.slug, "linked")}>
+                        Fechar
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              {needsGuidance && (
+                <div className="ml-7 mt-2 text-xs text-muted-foreground space-y-2">
+                  {status === "not_found" && (
+                    <div className="space-y-1.5">
+                      <p>Música não encontrada no Holyrics. Clique em <strong>Criar no Holyrics</strong> — isso abre um formulário de criação direto no aplicativo Holyrics (não no browser). Salve por lá e volte aqui.</p>
+                      {song.arrangements.length > 1 && (
+                        <label className="flex items-center gap-2">
+                          <span>Arranjo a exportar:</span>
+                          <select
+                            className="border rounded px-1.5 py-0.5 text-xs bg-white"
+                            value={getSelectedArrangement(song)?.id}
+                            onChange={(e) =>
+                              setSelectedArrangementIds((prev) => ({ ...prev, [song.slug]: Number(e.target.value) }))
+                            }
+                          >
+                            {song.arrangements.map((a) => (
+                              <option key={a.id} value={a.id}>{arrangementLabel(a)}</option>
+                            ))}
+                          </select>
+                        </label>
+                      )}
+                    </div>
+                  )}
+                  {!isLinked && status === "popup_open" && (
+                    <p>O formulário de criação abriu no <strong>aplicativo Holyrics</strong>. Salve a música lá e clique em <strong>Já salvei →</strong> para registrar o vínculo aqui.</p>
+                  )}
+                  {isLinked && status === "popup_open" && (
+                    <p>O formulário abriu novamente no <strong>aplicativo Holyrics</strong> com a letra atual. Se ele perguntar sobre duplicar, escolha <strong>atualizar a música existente</strong>. Depois clique em <strong>Concluído</strong>.</p>
+                  )}
+                  {!isLinked && status === "error" && (
+                    <div className="space-y-1.5">
+                      <p>Se a música existe no Holyrics mas o título é diferente, cole o ID dela abaixo (clique direito na música no Holyrics → Propriedades → ID).</p>
+                      <div className="flex gap-2">
+                        <input
+                          className="border rounded px-2 py-1 text-xs font-mono flex-1 min-w-0"
+                          placeholder="ID do Holyrics"
+                          value={manualIds[song.slug] ?? ""}
+                          onChange={(e) => setManualIds((prev) => ({ ...prev, [song.slug]: e.target.value }))}
+                        />
+                        <Button
+                          type="button"
+                          size="sm"
+                          onClick={() => linkManually(song)}
+                          disabled={!manualIds[song.slug]?.trim()}
+                        >
+                          Vincular
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function StatusIcon({ status }: { status: SongStatus | "linked" }) {
+  if (status === "linked") return <CheckCircle2 size={18} className="text-emerald-500 shrink-0" />;
+  if (status === "searching" || status === "linking") return <Loader2 size={18} className="animate-spin text-muted-foreground shrink-0" />;
+  if (status === "error") return <XCircle size={18} className="text-red-500 shrink-0" />;
+  if (status === "popup_open") return <Loader2 size={18} className="animate-spin text-emerald-500 shrink-0" />;
+  return <Circle size={18} className="text-muted-foreground shrink-0" />;
+}
+
+type WizardCardProps = {
+  song: SongRow;
+  status: SongStatus;
+  error: string;
+  index: number;
+  total: number;
+  manualId: string;
+  selectedArrangementId: number | undefined;
+  onOpenPopup: () => void;
+  onLinkAfterSave: () => void;
+  onRetry: () => void;
+  onPause: () => void;
+  onManualIdChange: (v: string) => void;
+  onLinkManually: () => void;
+  onArrangementChange: (id: number) => void;
+};
+
+function WizardCard({ song, status, error, index, total, manualId, selectedArrangementId, onOpenPopup, onLinkAfterSave, onRetry, onPause, onManualIdChange, onLinkManually, onArrangementChange }: WizardCardProps) {
+  return (
+    <div className="border-2 border-emerald-500 rounded-lg p-5 bg-emerald-50">
+      <div className="text-xs text-muted-foreground mb-1">{index + 1} de {total}</div>
+      <div className="font-semibold text-lg">{song.title}</div>
+      {song.artist && <div className="text-sm text-muted-foreground">{song.artist}</div>}
+
+      <div className="mt-4 space-y-3">
+        {(status === "searching" || status === "linking") && (
+          <p className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 size={14} className="animate-spin shrink-0" />
+            {status === "searching" ? "Verificando se já existe no Holyrics…" : "Salvando vínculo…"}
+          </p>
+        )}
+
+        {status === "linked" && (
+          <p className="flex items-center gap-2 text-sm text-emerald-700">
+            <CheckCircle2 size={14} className="shrink-0" /> Encontrada e vinculada. Avançando…
+          </p>
+        )}
+
+        {status === "not_found" && (
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">
+              Música não existe no Holyrics ainda. Clique abaixo para abrir o formulário de criação
+              direto no aplicativo Holyrics.
+            </p>
+            {song.arrangements.length > 1 && (
+              <label className="flex items-center gap-2 text-sm">
+                <span className="text-muted-foreground">Arranjo a exportar:</span>
+                <select
+                  className="border rounded px-1.5 py-1 text-sm bg-white"
+                  value={selectedArrangementId}
+                  onChange={(e) => onArrangementChange(Number(e.target.value))}
+                >
+                  {song.arrangements.map((a) => (
+                    <option key={a.id} value={a.id}>{arrangementLabel(a)}</option>
+                  ))}
+                </select>
+              </label>
+            )}
+            <Button type="button" onClick={onOpenPopup}>
+              Criar no Holyrics
+            </Button>
+          </div>
+        )}
+
+        {status === "popup_open" && (
+          <div className="space-y-2">
+            <p className="text-sm text-emerald-700 font-medium">
+              O Holyrics abriu o formulário de criação.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Verifique a letra, ajuste se necessário e salve a música no Holyrics. Depois volte aqui e clique em:
+            </p>
+            <Button type="button" onClick={onLinkAfterSave}>
+              Já salvei no Holyrics →
+            </Button>
+          </div>
+        )}
+
+        {status === "error" && (
+          <div className="space-y-2">
+            <p className="text-sm text-red-600">{error}</p>
+            <div className="flex gap-2 flex-wrap">
+              <Button type="button" variant="outline" onClick={onRetry}>
+                Tentar novamente
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Se a música existe no Holyrics com outro título, cole o ID dela abaixo (clique direito na música → Propriedades → ID).
+            </p>
+            <div className="flex gap-2">
+              <input
+                className="border rounded px-2 py-1 text-xs font-mono flex-1 min-w-0 bg-white"
+                placeholder="ID do Holyrics"
+                value={manualId}
+                onChange={(e) => onManualIdChange(e.target.value)}
+              />
+              <Button type="button" size="sm" onClick={onLinkManually} disabled={!manualId.trim()}>
+                Vincular
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <div>
+          <Button type="button" variant="ghost" size="sm" onClick={onPause}>
+            Pausar wizard
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(main)/admin/holyrics/page.tsx
+++ b/app/(main)/admin/holyrics/page.tsx
@@ -1,0 +1,74 @@
+export const dynamic = "force-dynamic";
+
+import Main from "@/components/common/Main";
+import prisma from "@/prisma/client";
+import HolyricsAdminClient from "./HolyricsAdminClient";
+
+export default async function AdminHolyricsPage() {
+  const [holyricsConfig, songs] = await Promise.all([
+    prisma.holyricsConfig.findUnique({ where: { id: 1 } }),
+    prisma.song.findMany({
+      where: { isDeleted: false },
+      orderBy: { title: "asc" },
+      select: {
+        slug: true,
+        title: true,
+        artist: true,
+        holyricsId: true,
+        arrangements: {
+          where: { isServiceArrangement: false, isDeleted: false },
+          orderBy: [{ isDefault: "desc" }, { id: "asc" }],
+          select: {
+            id: true,
+            key: true,
+            name: true,
+            isDefault: true,
+            units: {
+              orderBy: { order: "asc" },
+              select: { content: true, type: true, order: true },
+            },
+          },
+        },
+        _count: {
+          select: {
+            arrangements: { where: { isServiceArrangement: true, isDeleted: false } },
+          },
+        },
+      },
+    }),
+  ]);
+
+  const songsForClient = songs
+    .map((s) => ({
+      slug: s.slug,
+      title: s.title,
+      artist: s.artist,
+      holyricsId: s.holyricsId,
+      arrangements: s.arrangements.map((a) => ({
+        id: a.id,
+        key: a.key,
+        name: a.name,
+        isDefault: a.isDefault,
+        units: a.units,
+      })),
+      usedInServices: s._count.arrangements > 0,
+    }))
+    // orderBy do Postgres usa colação por byte (acentos vão para o fim); reordena com locale pt-BR
+    .sort((a, b) => a.title.localeCompare(b.title, "pt-BR", { sensitivity: "base" }));
+
+  return (
+    <Main>
+      <div className="max-w-3xl mx-auto py-8 px-4">
+        <h1 className="text-2xl font-display font-semibold mb-2">Integração Holyrics</h1>
+        <p className="text-muted-foreground mb-8 text-sm">
+          Exporte o catálogo de músicas para o Holyrics e envie setlists dos cultos.
+        </p>
+        <HolyricsAdminClient
+          songs={songsForClient}
+          initialToken={holyricsConfig?.token ?? ""}
+          initialHost={holyricsConfig?.host ?? "localhost:8091"}
+        />
+      </div>
+    </Main>
+  );
+}

--- a/app/api/holyrics-config/route.ts
+++ b/app/api/holyrics-config/route.ts
@@ -1,0 +1,25 @@
+import prisma from "@/prisma/client";
+import { NextRequest } from "next/server";
+
+export async function GET() {
+  const config = await prisma.holyricsConfig.findUnique({ where: { id: 1 } });
+  return Response.json({
+    token: config?.token ?? "",
+    host: config?.host ?? "localhost:8091"
+  });
+}
+
+export async function PATCH(request: NextRequest) {
+  const body = await request.json();
+
+  const updateData: { token?: string; host?: string } = {};
+  if (typeof body.token === "string") updateData.token = body.token;
+  if (typeof body.host === "string") updateData.host = body.host;
+
+  const config = await prisma.holyricsConfig.upsert({
+    where: { id: 1 },
+    update: updateData,
+    create: { id: 1, token: body.token ?? "", host: body.host ?? "localhost:8091" },
+  });
+  return Response.json({ token: config.token, host: config.host });
+}

--- a/app/api/songs/[slugOrId]/route.ts
+++ b/app/api/songs/[slugOrId]/route.ts
@@ -34,11 +34,12 @@ export async function PATCH(
     return Response.json({ success: true });
   }
 
-  if (body.title !== undefined || "artist" in body || Array.isArray(body.tagIds)) {
-    const data: { title?: string; artist?: string | null; tagIds?: number[] } = {};
+  if (body.title !== undefined || "artist" in body || Array.isArray(body.tagIds) || "holyricsId" in body) {
+    const data: { title?: string; artist?: string | null; tagIds?: number[]; holyricsId?: string | null } = {};
     if (body.title !== undefined) data.title = body.title;
     if ("artist" in body) data.artist = body.artist ?? null;
     if (Array.isArray(body.tagIds)) data.tagIds = body.tagIds;
+    if ("holyricsId" in body) data.holyricsId = body.holyricsId ?? null;
     await updateSongInfo(slugOrId, data);
     return Response.json({ success: true });
   }

--- a/components/service/ServiceHeader/HolyricsSetlistButton.tsx
+++ b/components/service/ServiceHeader/HolyricsSetlistButton.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { fetchHolyricsConfig, holyricsSetPlaylist, holyricsPopupCreateSong } from "@/lib/holyrics";
+import { ClientService } from "@/prisma/models";
+import { CheckCircle2, Circle, Loader2, Radio, RefreshCw, XCircle } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+
+type Props = { service: ClientService };
+
+export default function HolyricsSetlistButton({ service }: Props) {
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [sendError, setSendError] = useState("");
+  const [resyncingIndex, setResyncingIndex] = useState<number | null>(null);
+  const [resyncError, setResyncError] = useState<Record<number, string>>({});
+
+  const units = (service.units ?? [])
+    .filter((u) => u.arrangement?.song)
+    .sort((a, b) => a.order - b.order);
+
+  const allLinked = units.every((u) => u.arrangement?.song?.holyricsId);
+
+  async function sendToHolyrics() {
+    setSending(true);
+    setSent(false);
+    setSendError("");
+    try {
+      const config = await fetchHolyricsConfig();
+      const ids = units.map((u) => u.arrangement!.song!.holyricsId as string);
+      await holyricsSetPlaylist(config.token, config.host, ids);
+      setSent(true);
+    } catch (e) {
+      setSendError((e as Error).message);
+    } finally {
+      setSending(false);
+    }
+  }
+
+  async function resyncSong(index: number) {
+    const unit = units[index];
+    if (!unit.arrangement?.song) return;
+    setResyncingIndex(index);
+    setResyncError((prev) => ({ ...prev, [index]: "" }));
+    try {
+      await holyricsPopupCreateSong(
+        unit.arrangement.song.title,
+        unit.arrangement.song.artist,
+        unit.arrangement,
+        (await fetchHolyricsConfig()).host
+      );
+    } catch (e) {
+      setResyncError((prev) => ({ ...prev, [index]: (e as Error).message }));
+    }
+  }
+
+  function completeResync(index: number) {
+    setResyncingIndex(null);
+    setResyncError((prev) => ({ ...prev, [index]: "" }));
+  }
+
+  const triggerIcon = sending
+    ? <Loader2 size={18} className="animate-spin" />
+    : sent
+      ? <CheckCircle2 size={18} className="text-emerald-500" />
+      : <Radio size={18} className={!allLinked ? "text-amber-500" : ""} />;
+
+  return (
+    <Popover onOpenChange={() => { setSent(false); setSendError(""); }}>
+      <PopoverTrigger asChild>
+        <Button type="button" variant="ghost" size="icon" disabled={sending}>
+          {triggerIcon}
+          <span className="sr-only">Holyrics</span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-72 p-3" align="end">
+        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+          Setlist no Holyrics
+        </p>
+
+        {units.length === 0 ? (
+          <p className="text-sm text-muted-foreground">Nenhuma música no culto.</p>
+        ) : (
+          <ul className="space-y-1.5 mb-3">
+            {units.map((u, i) => {
+              const title = u.arrangement?.song?.title ?? "?";
+              const linked = !!u.arrangement?.song?.holyricsId;
+              const isResyncing = resyncingIndex === i;
+              return (
+                <li key={i} className="flex items-center gap-2 text-sm">
+                  {isResyncing ? (
+                    <Loader2 size={14} className="shrink-0 animate-spin text-emerald-500" />
+                  ) : linked ? (
+                    <CheckCircle2 size={14} className="shrink-0 text-emerald-500" />
+                  ) : (
+                    <Circle size={14} className="shrink-0 text-amber-500" />
+                  )}
+                  <span className={linked ? "" : "text-amber-700"}>{title}</span>
+                  {linked && !isResyncing && (
+                    <button
+                      type="button"
+                      className="ml-auto p-0.5 hover:bg-emerald-100 rounded transition-colors"
+                      onClick={() => resyncSong(i)}
+                      title="Ressincronizar arranjo no Holyrics"
+                    >
+                      <RefreshCw size={13} className="text-emerald-600" />
+                    </button>
+                  )}
+                  {isResyncing && (
+                    <button
+                      type="button"
+                      className="ml-auto text-xs px-2 py-0.5 bg-emerald-100 text-emerald-700 rounded hover:bg-emerald-200 transition-colors"
+                      onClick={() => completeResync(i)}
+                    >
+                      Concluído
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {resyncingIndex !== null && (
+          <div className="text-xs text-emerald-700 bg-emerald-50 rounded p-2 mb-3">
+            O formulário abriu no <strong>Holyrics</strong>. Atualize o arranjo e salve por lá. Depois clique em <strong>Concluído</strong> aqui.
+          </div>
+        )}
+
+        {!allLinked && (
+          <div className="text-xs text-amber-700 bg-amber-50 rounded p-2 mb-3 flex items-start gap-1.5">
+            <XCircle size={13} className="shrink-0 mt-0.5" />
+            <span>
+              Algumas músicas não estão vinculadas ao Holyrics.{" "}
+              <Link href="/admin/holyrics" className="underline font-medium">
+                Exportar catálogo
+              </Link>
+            </span>
+          </div>
+        )}
+
+        {sendError && (
+          <p className="text-xs text-red-600 mb-3">{sendError}</p>
+        )}
+
+        {Object.entries(resyncError).map(([idx, err]) => err && (
+          <p key={idx} className="text-xs text-red-600 mb-2">{err}</p>
+        ))}
+
+        {sent && (
+          <p className="text-xs text-emerald-600 mb-3">Setlist enviado com sucesso!</p>
+        )}
+
+        <Button
+          type="button"
+          size="sm"
+          className="w-full"
+          disabled={sending || units.length === 0 || !allLinked}
+          onClick={sendToHolyrics}
+        >
+          {sending
+            ? <><Loader2 size={14} className="mr-1 animate-spin" /> Enviando…</>
+            : "Enviar setlist"}
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/service/ServiceHeader/index.tsx
+++ b/components/service/ServiceHeader/index.tsx
@@ -7,6 +7,7 @@ import { ClientService, ServiceRef } from "@/prisma/models";
 import { Calendar, ChevronLeft, ChevronRight, MicVocal, SlidersHorizontal } from "lucide-react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
+import HolyricsSetlistButton from "./HolyricsSetlistButton";
 import ServiceActionMenu from "./ServiceActionMenu";
 import ServiceConfig from "./ServiceConfig";
 import Skeleton from "./Skeleton";
@@ -35,6 +36,7 @@ export default function ServiceHeader({ service }: ServiceHeaderProps) {
             <ServiceNavButton dir="prev" serviceRef={service.prevService} />
             <ServiceNavButton dir="next" serviceRef={service.nextService} />
             <div className="w-px h-5 bg-border mx-1" />
+            <HolyricsSetlistButton service={service} />
             <PopoverTrigger asChild>
               <Button variant="ghost" size="icon">
                 <SlidersHorizontal />

--- a/lib/holyrics.ts
+++ b/lib/holyrics.ts
@@ -1,0 +1,88 @@
+import { getLyrics } from "@/chopro/music";
+import { ClientArrangement } from "@/prisma/models";
+
+export type HolyricsConfig = { token: string; host: string };
+
+export async function fetchHolyricsConfig(): Promise<HolyricsConfig> {
+  const res = await fetch("/api/holyrics-config");
+  if (!res.ok) return { token: "", host: "localhost:8091" };
+  return res.json();
+}
+
+function apiUrl(action: string, token: string, host: string) {
+  return `http://${host}/api/${action}?token=${token}`;
+}
+
+// O Holyrics retorna erros (ex: permissão negada) com HTTP 200 e
+// { status: "error", error: ... } no corpo — checar só res.ok não basta.
+async function holyricsApiCall(action: string, token: string, host: string, body: unknown = {}): Promise<any> {
+  const res = await fetch(apiUrl(action, token, host), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`${action} falhou (HTTP ${res.status}). Verifique se o Holyrics está aberto e acessível.`);
+  }
+  const json = await res.json();
+  if (json?.status === "error") {
+    const err = json.error;
+    const message = typeof err === "string" ? err : err?.message ?? JSON.stringify(err);
+    throw new Error(`${action} falhou: ${message}. Verifique se a permissão "${action}" está habilitada para o token.`);
+  }
+  return json;
+}
+
+export async function holyricsPopupCreateSong(
+  title: string,
+  artist: string | null | undefined,
+  arrangement: ClientArrangement,
+  host: string = "localhost:8091"
+): Promise<void> {
+  const units = [...(arrangement.units ?? [])].sort((a, b) => a.order - b.order);
+
+  const paragraphs = units
+    .map((unit) => ({
+      text: getLyrics(unit.content)?.trim() ?? "",
+      description: unit.type.toLowerCase(),
+    }))
+    .filter((p) => p.text.length > 0);
+
+  const body: Record<string, unknown> = { title, paragraphs };
+  if (artist) body.artist = artist;
+
+  const res = await fetch(`http://${host}/api/popup-createsong`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) throw new Error(`popup-createsong falhou: ${res.status}`);
+}
+
+export async function holyricsSearchSong(token: string, host: string, title: string): Promise<string | null> {
+  const json = await holyricsApiCall("SearchSong", token, host, { text: title, search_title: true });
+  const results: { id: string; title: string }[] = json?.data ?? [];
+  const exact = results.find(
+    (s) => s.title.toLowerCase().trim() === title.toLowerCase().trim()
+  );
+  return exact?.id ?? results[0]?.id ?? null;
+}
+
+export async function holyricsSetPlaylist(token: string, host: string, holyricsIds: string[]): Promise<void> {
+  // Busca a playlist atual
+  const currentData = await holyricsApiCall("GetLyricsPlaylist", token, host, {});
+  const currentPlaylist = currentData?.data ?? [];
+
+  // Remove TODOS os itens atuais (limpa a playlist)
+  if (currentPlaylist.length > 0) {
+    const indexesToRemove = Array.from({ length: currentPlaylist.length }, (_, i) => i);
+    await holyricsApiCall("RemoveFromLyricsPlaylist", token, host, { indexes: indexesToRemove });
+  }
+
+  // Adiciona as novas músicas (SetLyricsPlaylistItem só altera item já existente,
+  // não cria; para adicionar é necessário usar AddLyricsToPlaylist)
+  if (holyricsIds.length > 0) {
+    await holyricsApiCall("AddLyricsToPlaylist", token, host, { ids: holyricsIds });
+  }
+}

--- a/prisma/data.ts
+++ b/prisma/data.ts
@@ -147,6 +147,7 @@ export async function retrieveSongs({
       lyrics: true,
       artist: true,
       isDeleted: true,
+      holyricsId: true,
       arrangements: {
         where: { isServiceArrangement: false, isDeleted: false },
         select: {
@@ -218,7 +219,7 @@ export async function archiveSong(slug: string) {
 
 export async function updateSongInfo(
   slug: string,
-  data: { title?: string; artist?: string | null; tagIds?: number[] }
+  data: { title?: string; artist?: string | null; tagIds?: number[]; holyricsId?: string | null }
 ): Promise<void> {
   const { tagIds, ...rest } = data;
   await prisma.song.update({

--- a/prisma/migrations/20260704164609_add_holyrics_integration/migration.sql
+++ b/prisma/migrations/20260704164609_add_holyrics_integration/migration.sql
@@ -1,0 +1,11 @@
+-- AlterTable
+ALTER TABLE "Song" ADD COLUMN     "holyricsId" TEXT;
+
+-- CreateTable
+CREATE TABLE "HolyricsConfig" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "token" TEXT NOT NULL DEFAULT '',
+    "host" TEXT NOT NULL DEFAULT 'localhost:8091',
+
+    CONSTRAINT "HolyricsConfig_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/models.ts
+++ b/prisma/models.ts
@@ -36,8 +36,9 @@ export const SONG_UNIT_TYPES = [
   "TEXT",
 ] as const;
 
-export type ClientSong = Omit<Song, "id" | "legacyId"> & {
+export type ClientSong = Omit<Song, "id" | "legacyId" | "holyricsId"> & {
   id?: number;
+  holyricsId?: string | null;
   arrangements?: ClientArrangement[];
   tags?: ClientTag[];
   lastUsedAt?: Date | null;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,16 +16,23 @@ datasource db {
 }
 
 model Song {
-  id        Int     @id @default(autoincrement())
-  legacyId  Int? @unique
-  title     String
-  slug      String @unique
-  lyrics    String
-  artist    String?
-  isDeleted Boolean @default(false)
+  id         Int     @id @default(autoincrement())
+  legacyId   Int? @unique
+  title      String
+  slug       String @unique
+  lyrics     String
+  artist     String?
+  isDeleted  Boolean @default(false)
+  holyricsId String?
 
   arrangements SongArrangement[]
   tags         Tag[]
+}
+
+model HolyricsConfig {
+  id    Int    @id @default(1)
+  token String @default("")
+  host  String @default("localhost:8091")
 }
 
 model TagGroup {


### PR DESCRIPTION
## Resumo
- Replica a integração com o Holyrics já validada no chorder-alt: `Song.holyricsId` + model `HolyricsConfig` (singleton token/host), cliente browser-side (`lib/holyrics.ts`) que fala direto com a API REST local do Holyrics na rede da igreja.
- Página `/admin/holyrics` pra configurar token/host e vincular cada música do catálogo a um ID do Holyrics (buscar existente, criar novo ou entrada manual), com modo de vincular pendentes em sequência.
- Botão no `ServiceHeader` pra enviar a setlist do culto (músicas já vinculadas) como playlist do Holyrics.

## Test plan
- [x] `npx tsc --noEmit` sem erros
- [x] Testado localmente rodando chorder e Holyrics na mesma máquina — configurar token/host, buscar/vincular música no catálogo, enviar setlist de um culto
- [ ] Testar em produção com Holyrics numa máquina separada na rede da igreja (teste entre duas máquinas nesta sessão esbarrou em isolamento de cliente Wi-Fi/firewall doméstico, não relacionado ao código)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)