### PR TITLE
fix: forçar limpeza do Prisma Client gerado antes do build no Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "WATCHPACK_POLLING=true DATABASE_URL='postgresql://postgres:postgres@localhost:5432/chorder?schema=public' DIRECT_URL='postgresql://postgres:postgres@localhost:5432/chorder?schema=public' next dev -H 0.0.0.0 --turbopack",
-    "build": "prisma generate && (prisma migrate resolve --rolled-back 20260526020946_move_youtube_url_to_arrangement || true) && prisma migrate deploy && next build",
+    "build": "rm -rf node_modules/.prisma .next/cache && prisma generate && (prisma migrate resolve --rolled-back 20260526020946_move_youtube_url_to_arrangement || true) && prisma migrate deploy && next build",
     "start": "next start -H 0.0.0.0",
     "test": "vitest run",
     "test:watch": "vitest watch",


### PR DESCRIPTION
## Resumo
- Após o merge do #49 (integração Holyrics), `/admin/holyrics` e `/api/songs` começaram a falhar em produção com `TypeError: Cannot read properties of undefined (reading 'findUnique')` e `PrismaClientValidationError` — indícios de o Vercel ter reaproveitado um Prisma Client gerado antes da mudança de schema.
- Localmente, com build limpo (`rm -rf node_modules/.prisma .next/cache && prisma generate && ...`), a mesma migration/schema funciona sem erro — reforça que é cache de build, não bug de código.
- Adiciona limpeza forçada de `node_modules/.prisma` e `.next/cache` no início do script de `build`, antes do `prisma generate`, garantindo client sempre fresco independente do cache do Vercel.

## Test plan
- [x] `yarn build` local com a limpeza forçada — build completo sem erros
- [ ] Após merge/deploy, confirmar `/admin/holyrics` e `/api/songs` voltam a responder 200 em produção

🤖 Gerado com [Claude Code](https://claude.com/claude-code)