### PR TITLE
fix: forçar inclusão do Prisma Client no bundle de função serverless (Vercel)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,13 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },
+  // Garante que o Prisma Client gerado seja incluído no bundle de toda função
+  // serverless, independente do que o rastreamento automático de arquivos do
+  // Next detectar — evita rotas ficarem com um client desatualizado/incompleto
+  // depois de mudanças no schema (visto em produção após adicionar HolyricsConfig).
+  outputFileTracingIncludes: {
+    '/**/*': ['./node_modules/.prisma/client/**/*'],
+  },
 };
 
 module.exports = withNextIntl(nextConfig);


### PR DESCRIPTION
## Resumo
- Após o merge do #49 (Holyrics) e #50 (tentativa de fix via limpeza de cache), `/admin/holyrics` e `/api/songs` continuam falhando em produção com `TypeError: Cannot read properties of undefined (reading 'findUnique')` / `PrismaClientValidationError`, mesmo com:
  - Migration confirmada aplicada no Neon (`Song.holyricsId` existe, verificado via SQL direto)
  - Deployment confirmado como o mais recente (via GitHub Deployments API)
  - Mesmo comportamento em dois domínios diferentes (`liturgias.imelsaude.org.br` e `chorder-plum.vercel.app`) — descarta problema de alias de domínio
  - Build local (`next build && next start`) funcionando sem erro com a mesma migration
- Outras queries Prisma (Service, Song sem `holyricsId`) funcionam normalmente na mesma produção — só as rotas que tocam os campos/model novos (`holyricsId`, `HolyricsConfig`) quebram.
- Diagnóstico: bundle da função serverless dessas rotas não está empacotando os arquivos novos do Prisma Client gerado — problema conhecido de rastreamento de arquivos do Next.js na Vercel após mudança de schema Prisma. `next start` local não isola por rota, por isso não reproduz.

## Mudança
- `next.config.js`: `outputFileTracingIncludes` forçando `node_modules/.prisma/client/**/*` em todo bundle de função, independente da detecção automática de rastreamento.

## Test plan
- [x] `yarn build` local — sucesso (não reproduz o bug em si, só confirma que a config não quebra o build; ver observação no PR)
- [ ] Após deploy, confirmar `/admin/holyrics` e `/api/songs` voltam a responder 200 em produção — só esse teste valida o fix de verdade

⚠️ Não mergear sem autorização explícita — aguardando confirmação.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)