### PR TITLE
fix: forçar Turbo a ignorar cache no build da Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-  "buildCommand": "yarn turbo build",
+  "buildCommand": "yarn turbo build --force",
   "ignoreCommand": "npx turbo-ignore"
 }


### PR DESCRIPTION
## Resumo
- Causa raiz real dos 500 em `/admin/holyrics` e `/api/songs` desde o merge da integração Holyrics (#49): a Vercel não roda o script `build` do `package.json` — `vercel.json` define `buildCommand: "yarn turbo build"`, passando pelo cache do Turborepo.
- As duas tentativas anteriores (#50: limpar `node_modules/.prisma`/`.next/cache` no script; #51: `outputFileTracingIncludes` no `next.config.js`) não resolveram porque, se o Turbo considerar a task `build` um cache hit, ele **nem executa o script** — só copia `.next/**` de um build anterior, de antes da migration.
- Confirmado direto no log de produção: `PrismaClientValidationError: Unknown field \`holyricsId\`` e `TypeError: Cannot read properties of undefined (reading 'findUnique')` persistindo de forma consistente através de dois deploys "corrigidos" com sucesso.

## Mudança
- `vercel.json`: `buildCommand` ganha `--force`, forçando o Turbo a sempre ignorar cache nos builds da Vercel.

## Test plan
- [x] `yarn turbo build --force` local — sucesso, log confirma `Cached: 0 cached, 1 total`
- [ ] Após deploy, confirmar `/admin/holyrics` e `/api/songs` voltam a responder 200 em produção

⚠️ Não mergear sem autorização explícita.

🤖 Gerado com [Claude Code](https://claude.com/claude-code)